### PR TITLE
Plot object access

### DIFF
--- a/angular-flot.coffee
+++ b/angular-flot.coffee
@@ -5,6 +5,7 @@ angular.module 'angular-flot', []
         scope:
             dataset: '='
             options: '='
+            callback: '='
         link: (scope, element, attributes) ->
             #
             # Options
@@ -32,7 +33,10 @@ angular.module 'angular-flot', []
                 height: height
 
             init = ->
-                $.plot plotArea, scope.dataset, scope.options
+                plotObj = $.plot plotArea, scope.dataset, scope.options
+                if scope.callback
+                    scope.callback(plotObj);
+                plotObj
 
             #
             # Watches

--- a/angular-flot.js
+++ b/angular-flot.js
@@ -5,7 +5,8 @@ angular.module('angular-flot', []).directive('flot', function() {
     template: '<div></div>',
     scope: {
       dataset: '=',
-      options: '='
+      options: '=',
+      callback: '='
     },
     link: function(scope, element, attributes) {
       var height, init, onDatasetChanged, onOptionsChanged, plot, plotArea, width;
@@ -28,7 +29,12 @@ angular.module('angular-flot', []).directive('flot', function() {
         height: height
       });
       init = function() {
-        return $.plot(plotArea, scope.dataset, scope.options);
+        var plotObj;
+        plotObj = $.plot(plotArea, scope.dataset, scope.options);
+        if (scope.callback) {
+          scope.callback(plotObj);
+        }
+        return plotObj;
       };
       onDatasetChanged = function(dataset) {
         if (plot) {


### PR DESCRIPTION
There are times when developers might need direct access to the Flot `Plot` object.  For me, it was to be able to call the `highlight` and `unhighlight` methods.  These are (presumably) specified outside the `dataset` (by Flot) because they involve the overlay layer.  So it isn't possible to use just the `dataset` variable to specify how highlight should be done.

I thought about simply adding some data to specify highlight information in addition to `dataset`, but I was concerned about not having a rich enough "API" to handle all cases.  This approach leaves it up to the developer to decide what to do.

I should point out that this is 100% backward compatible and doesn't make things any more complicated for the 95% of cases that don't involve needing the `Plot` object.  But for those 5% cases, it could be useful.

Let me know what you think.
