### PR TITLE
fix error on changing dataset after first init

### DIFF
--- a/angular-flot.coffee
+++ b/angular-flot.coffee
@@ -50,7 +50,7 @@ angular.module 'angular-flot', []
                 else
                     plot = do init
 
-            scope.$watch 'dataset', onDatasetChanged, true
+            scope.$watchCollection 'dataset', onDatasetChanged, true
 
             onOptionsChanged = ->
                 plot = do init

--- a/angular-flot.js
+++ b/angular-flot.js
@@ -45,7 +45,7 @@ angular.module('angular-flot', []).directive('flot', function() {
           return plot = init();
         }
       };
-      scope.$watch('dataset', onDatasetChanged, true);
+      scope.$watchCollection('dataset', onDatasetChanged, true);
       onOptionsChanged = function() {
         return plot = init();
       };


### PR DESCRIPTION
Hey,

had one error when changing dataset after first init:

```
Error: [$rootScope:infdig] 10 $digest() iterations reached. Aborting!
Watchers fired in the last 5 iterations: [["dataset; newVal: [{\"color\":\"#edab98\",\"label\":\"Prospects 10     
%\",\"data\":[[\"2013-06-30T22:00:00.000Z\",0],[\"2013-07-31T22:00:00.000Z\",0],[\"2013-08-
31T22:00:00.000Z\",0],[\"2013-09-30T22:00:00.000Z\",0],[\"2013-10-31T23:00:00.000Z\",0],[\"2013-11-
30T23:00:00.000Z\",0],[\"2013-12-31T23:00:00.000Z\",0],[\"2014-01-31T23:00:00.000Z\",0],[\"2014-02- [...]
```

This PR fixes this :-)
