### PR TITLE
add missing semi colon

### DIFF
--- a/angular-flot.js
+++ b/angular-flot.js
@@ -113,4 +113,4 @@ angular.module('angular-flot', []).directive('flot', function () {
       })
     }
   }
-})
+});


### PR DESCRIPTION
as a dependency in my angular project, the missing semicolon would break my build, which thought the next statement was actually an argument being passed into the directive call
