### PR TITLE
avoid plot init twice

### DIFF
--- a/angular-flot.js
+++ b/angular-flot.js
@@ -81,6 +81,12 @@ angular.module('angular-flot', []).directive('flot', function () {
       // Watches
       //
 
+      var onOptionsChanged = function () {
+        plot = init();
+      };
+
+      var unwatchOptions = scope.$watch('options', onOptionsChanged, true);
+
       var onDatasetChanged = function (dataset) {
         if (plot) {
           plot.setData(dataset);
@@ -93,12 +99,6 @@ angular.module('angular-flot', []).directive('flot', function () {
       };
 
       var unwatchDataset = scope.$watch('dataset', onDatasetChanged, true);
-
-      var onOptionsChanged = function () {
-        plot = init();
-      };
-
-      var unwatchOptions = scope.$watch('options', onOptionsChanged, true);
 
       //
       // Tear Down


### PR DESCRIPTION
When setting both dataset and options, the onOptionsChanged will act after the onDatasetChanged, and the plot will init twice, and this will cause the callback method will be called twice.