### PR TITLE
Call plot.shutdown on destroy

### DIFF
--- a/angular-flot.js
+++ b/angular-flot.js
@@ -105,7 +105,7 @@ angular.module('angular-flot', []).directive('flot', function () {
         width = value;
         plotArea.css('width', value);
       });
-      
+
       attributes.$observe('height', function(value) {
         if (!value) return;
         height = value;
@@ -119,7 +119,7 @@ angular.module('angular-flot', []).directive('flot', function () {
       element.on('$destroy', function onDestroy () {
         plotArea.off('plotclick');
         plotArea.off('plothover');
-
+        plot.shutdown();
         unwatchDataset();
         unwatchOptions();
       });


### PR DESCRIPTION
So that shutdown hooks are properly triggered when the plot is destroyed.