### PR TITLE
added support for plot selection

### DIFF
--- a/angular-flot.js
+++ b/angular-flot.js
@@ -11,7 +11,8 @@ angular.module('angular-flot', []).directive('flot', function () {
       options: '=',
       callback: '=',
       onPlotClick: '&',
-      onPlotHover: '&'
+      onPlotHover: '&',
+      onPlotSelected: '&'
     },
     link: function (scope, element, attributes) {
       var plot = null;
@@ -63,6 +64,15 @@ angular.module('angular-flot', []).directive('flot', function () {
             event: event,
             pos: pos,
             item: item
+          });
+        });
+      });
+
+      plotArea.on('plotselected', function onPlotSelected (event, ranges) {
+        scope.$apply(function onApplyPlotSelected () {
+          scope.onPlotSelected({
+            event: event,
+            ranges: ranges
           });
         });
       });
@@ -119,6 +129,8 @@ angular.module('angular-flot', []).directive('flot', function () {
       element.on('$destroy', function onDestroy () {
         plotArea.off('plotclick');
         plotArea.off('plothover');
+        plotArea.off('plotselected');
+
         plot.shutdown();
         unwatchDataset();
         unwatchOptions();


### PR DESCRIPTION
This makes it possibly to select area from plot, and ie. make zoom support.

Examble of zooming:

Zoom function:

$scope.zoomPlot = function( pos, ranges) {
		report.options.xaxis.min =  ranges.xaxis.from;
		report.options.xaxis.max =  ranges.xaxis.to;
}

HTML:

<flot dataset="report.dataset" options="report.options" on-plot-selected="zoomPlot(event, ranges)"></flot>


And options:

report.options = {
 ...
		selection: {
			mode: "x"
		}
...
	};