### PR TITLE
Clean up memory leaks

### DIFF
--- a/angular-flot.js
+++ b/angular-flot.js
@@ -155,7 +155,7 @@ angular.module('angular-flot', []).directive('flot', ['$timeout', function ($tim
         plotArea.off('plothover');
         plotArea.off('plotselected');
 
-        plot.shutdown();
+        plot.destroy();
         unwatchDataset();
         unwatchOptions();
       });


### PR DESCRIPTION
Use `plot.destroy()` instead of `plot.shutdown()` to clean up memory, implementing what was done in this [PR](https://github.com/flot/flot/pull/1130/files)